### PR TITLE
Display readable duration times

### DIFF
--- a/lib/reporters/spec.js
+++ b/lib/reporters/spec.js
@@ -3,6 +3,7 @@
  */
 
 var Base = require('./base');
+var ms = require('../ms');
 var inherits = require('../utils').inherits;
 var color = Base.color;
 var cursor = Base.cursor;
@@ -63,9 +64,9 @@ function Spec(runner) {
       fmt = indent()
         + color('checkmark', '  ' + Base.symbols.ok)
         + color('pass', ' %s')
-        + color(test.speed, ' (%dms)');
+        + color(test.speed, ' (%s)');
       cursor.CR();
-      console.log(fmt, test.title, test.duration);
+      console.log(fmt, test.title, ms(test.duration));
     }
   });
 


### PR DESCRIPTION
When having long-running tests, it is more easily readable with human-readable duration times.
